### PR TITLE
Change char limit to note limit

### DIFF
--- a/src/bongocat.js
+++ b/src/bongocat.js
@@ -39,11 +39,13 @@ var playing = false;
 setBPM(128);
 var githubUrl = "https://raw.githubusercontent.com/jvpeek/twitch-bongocat/master/songs/";
 
+window.maxNotesPerBatch = 5;
+
 // ====================================================== //
 // ================== notation handlers ================= //
 // ====================================================== //
-
 var notations = {};
+
 notations["bongo"] = parseSongBongo;
 notations["legacy"] = parseSongBongo;
 notations["bongo+"] = parseSongBongo;
@@ -224,7 +226,6 @@ function checkQueue()
 // ====================================================== //
 // ===================== remote play ==================== //
 // ====================================================== //
-
 async function playFromGithub(song, user)
 {
   console.log("Playing", song, "from github for", user);
@@ -245,8 +246,8 @@ async function playFromGithub(song, user)
 // ====================================================== //
 // ====================== commands ====================== //
 // ====================================================== //
-
 const commands = {};
+
 function enableBongo(args)
 {
   if (isSuperUser(args.tags))
@@ -357,9 +358,20 @@ function handleCommand(message, command, arg, tags)
 
 
 // ====================================================== //
+// ======================= config ======================= //
+// ====================================================== //
+let params = new URLSearchParams(document.location.search);
+
+let maxNotesPerBatch = params.get("maxNotesPerBatch");
+if (maxNotesPerBatch && Number(maxNotesPerBatch))
+{
+  window.maxNotesPerBatch = Number(maxNotesPerBatch);
+}
+
+// ====================================================== //
 // ======================== tmijs ======================= //
 // ====================================================== //
-const channel = location.hash || 'jvpeek';
+const channel = location.hash || params.get("channel") || 'jvpeek';
 const chatClient = new tmi.Client({
   channels: [channel]
 });

--- a/src/modules/bongo.js
+++ b/src/modules/bongo.js
@@ -23,7 +23,7 @@ function addNotes(noteString, isLegacyNotation, username) {
   uBPM = getBPM(username);
 
   for (var noteBatch in noteBatches) {
-    var notes = parseNotes(noteBatches[noteBatch].substr(0, 5));
+    var notes = parseNotes(noteBatches[noteBatch]).slice(0, maxNotesPerBatch);
     if (notes.length > 0 && notes[0] == ",") {
       let sBpm = "";
       for (var i = 1; i <= notes.length; i++) {


### PR DESCRIPTION
Ersetzt das zeichenlimit durch ein notenlimit.
Die zeichen pro takt waren auf 5 begrenzt was einem parallelem notenlimit von 5 in der legacy/bongo syntax gleicht.
Da in der bongo+ syntax eine note aus mehreren zeichen bestehen kann, führt ein zeichen limit dazu, dass nicht alle noten korrekt erkannt werden.
Das notenlimit ist standardmäßig auf 5 gesetzt und kann mit dem query parameter `maxNotesPerBatch` überschrieben werden (!Achtung keine validierung: werte <= 0 sorgen für eine unbenutzbare bongocat) 