### PR TITLE
change maxNotesPerBatch from 5 to 9

### DIFF
--- a/src/bongocat.js
+++ b/src/bongocat.js
@@ -39,7 +39,7 @@ var playing = false;
 setBPM(128);
 var githubUrl = "https://raw.githubusercontent.com/jvpeek/twitch-bongocat/master/songs/";
 
-window.maxNotesPerBatch = 5;
+window.maxNotesPerBatch = 9;
 
 // ====================================================== //
 // ================== notation handlers ================= //


### PR DESCRIPTION
Bug detected. Notes can be modified with up to 3 characters in length, which means that up to 9 characters can occur when there are 3 parallel notes. However, currently only 5 characters are accepted in parallel, resulting in the error of notes being cut off an get read wrong. 

example:
"v1#v2#v4#" > "v1#v2" (v2# becomes v2)
^5^16# > ^5^16 (6# become 6)
fix:
change maxNotesPerBatch from 5 to 9